### PR TITLE
allow console to get URI and domain values from env

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -10,6 +10,8 @@ Dotenv.load
 ZohoHub.configure do |config|
   config.client_id    = ENV['ZOHO_CLIENT_ID']
   config.secret       = ENV['ZOHO_SECRET']
+  config.redirect_uri = ENV['ZOHO_REDIRECT_URI']
+  config.api_domain   = ENV['ZOHO_API_DOMAIN'] if ENV['ZOHO_API_DOMAIN']
   config.debug        = ENV['ZOHO_DEBUG'] || false
 end
 


### PR DESCRIPTION
This is a tiny addition to only the console, but it clarifies configuration and would have helped me get the gem working sooner (and hopefully will do the same for others new to the code.)