### PR TITLE
leverage Rails inflector if in a Rails app

### DIFF
--- a/lib/zoho_hub/string_utils.rb
+++ b/lib/zoho_hub/string_utils.rb
@@ -8,7 +8,11 @@ module ZohoHub
       end
 
       def pluralize(text)
-        "#{text}s"
+        if ENV.has_key? 'RAILS_ENV'
+          ActiveSupport::Inflector.pluralize text
+        else
+          "#{text}s"
+        end
       end
 
       def camelize(text)


### PR DESCRIPTION
It would be convenient to enable use of Rails' inflector (for pluralizing) if this gem is running in a Rails app.