### PR TITLE
feature: add support for HTTP DELETE to Connection class and WithConn…

### DIFF
--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -47,6 +47,13 @@ module ZohoHub
       response.body
     end
 
+    def delete(path, params = {})
+      log "DELETE #{path} with #{params}"
+
+      response = with_refresh { adapter.delete(path, params) }
+      response.body
+    end
+
     def access_token?
       @access_token
     end

--- a/lib/zoho_hub/with_connection.rb
+++ b/lib/zoho_hub/with_connection.rb
@@ -19,6 +19,10 @@ module ZohoHub
       def put(path, params = {})
         ZohoHub.connection.put(path, params.to_json)
       end
+
+      def delete(path, params = {})
+        ZohoHub.connection.delete(path, params.to_json)
+      end
     end
 
     def get(path, params = {})
@@ -31,6 +35,10 @@ module ZohoHub
 
     def put(path, params = {})
       self.class.put(path, params)
+    end
+
+    def delete(path, params = {})
+      self.class.delete(path, params)
     end
   end
 end


### PR DESCRIPTION
…ection module

This adds `Connection.delete` similar to existing `get`, `post`, and `put` methods. I haven't added anything to `BaseRecord` to actually invoke `delete`. I figure as destructive is it could be, it could be up to users to implement their own access in their record class(es). But I'd be happy to add something to `BaseRecord` if you'd like.

Also, I opened this pull request from a branch matching your current master branch so you could review both of my open PRs in isolation. If it would be more helpful to merge them then submit a PR, I'm happy to do that. Thanks for this handy project!