### PR TITLE
BaseRecord: allow find_by() and where() with any attribute

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -42,6 +42,17 @@ module ZohoHub
       def where(params)
         path = File.join(request_path, 'search')
 
+        if params.size == 1
+          params = case params.keys.first
+                   when :criteria, :email, :phone, :word
+                     # these attributes are directly handled by Zoho
+                     # see https://www.zoho.com/crm/help/developer/api/search-records.html
+                     params
+                   else
+                     { criteria: "#{attr_to_zoho_key(params.keys.first)}:equals:#{params.values.first}" }
+                   end
+        end
+
         body = get(path, params)
         response = build_response(body)
 

--- a/lib/zoho_hub/with_attributes.rb
+++ b/lib/zoho_hub/with_attributes.rb
@@ -43,6 +43,11 @@ module ZohoHub
         @attribute_translation = translation
       end
 
+      def attr_to_zoho_key(attr_name)
+       return attribute_translation[attr_name.to_sym] if attribute_translation.key?(attr_name.to_sym)
+       attr_name.to_s.split('_').map(&:capitalize).join('_').to_sym
+      end
+
       def zoho_key_translation
         @attribute_translation.to_a.map(&:rotate).to_h
       end
@@ -56,11 +61,7 @@ module ZohoHub
     private
 
     def attr_to_zoho_key(attr_name)
-      translations = self.class.attribute_translation
-
-      return translations[attr_name.to_sym] if translations.key?(attr_name.to_sym)
-
-      attr_name.to_s.split('_').map(&:capitalize).join('_').to_sym
+      self.class.attr_to_zoho_key(attr_name)
     end
 
     def zoho_key_to_attr(zoho_key)


### PR DESCRIPTION
The goal here is to use `find_by` and `where` with any attribute. E.g. to be able to write `Zoho::Lead.find_by(last_name: "Snow")`