### PR TITLE
fix: NoMethodError when calling WithConnection::delete

### DIFF
--- a/lib/zoho_hub/with_connection.rb
+++ b/lib/zoho_hub/with_connection.rb
@@ -21,7 +21,7 @@ module ZohoHub
       end
 
       def delete(path, params = {})
-        ZohoHub.connection.delete(path, params.to_json)
+        ZohoHub.connection.delete(path, params)
       end
     end
 


### PR DESCRIPTION
params Hash was being converted to a String with to_json
Faraday eventually calls each on params, which caused the NoMethodError
(each for String)
fix by removing to_json call on params