### PR TITLE
Base record: add update method

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -121,6 +121,11 @@ module ZohoHub
       response.data.first.dig(:details, :id)
     end
 
+    def update(params)
+      params.map { |key, value| send("#{key}=", value) }
+      save
+    end
+
     def new_record?
       !id
     end


### PR DESCRIPTION
I propose in this small PR to implement an `update` method in `BaseRecord`.
e.g. `zoho_lead.update(last_name: "YYY")`