### PR TITLE
Base record: add update methods

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -70,6 +70,10 @@ module ZohoHub
         new(params).save
       end
 
+      def update(id, params)
+        new(id: id).update(params)
+      end
+
       def all(params = {})
         params[:page] ||= DEFAULT_PAGE
         params[:per_page] ||= DEFAULT_RECORDS_PER_PAGE
@@ -119,6 +123,11 @@ module ZohoHub
       response = build_response(body)
 
       response.data.first.dig(:details, :id)
+    end
+
+    def update(params)
+      zoho_params = params.transform_keys { |key| attr_to_zoho_key(key) }
+      put(File.join(self.class.request_path, id), data: [zoho_params])
     end
 
     def new_record?


### PR DESCRIPTION
As discussed [in the previous PR](https://github.com/rikas/zoho_hub/pull/14), here is a new implementation of the `update` method, avoiding an update of unwanted parameters.
Also, I added a class method for updating a record with a known id.