### PR TITLE
Handle error codes in array

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -121,6 +121,11 @@ module ZohoHub
       response.data.first.dig(:details, :id)
     end
 
+    def update(params)
+      params.map { |key, value| send("#{key}=", value) }
+      save
+    end
+
     def new_record?
       !id
     end

--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -127,7 +127,8 @@ module ZohoHub
 
     def update(params)
       zoho_params = params.transform_keys { |key| attr_to_zoho_key(key) }
-      put(File.join(self.class.request_path, id), data: [zoho_params])
+      body = put(File.join(self.class.request_path, id), data: [zoho_params])
+      response = build_response(body)
     end
 
     def new_record?


### PR DESCRIPTION
Since [this commit](https://github.com/rikas/zoho_hub/pull/8/commits/63c7c206a1852e123c6b4e818130aa8a1e1592e5), the response error codes are not correctly handled when `data` is an array.

Here is a fix proposition, used in `BaseRecord#update`.