### PR TITLE
feat: infer connection api_domain from config

### DIFF
--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -9,6 +9,18 @@ require 'zoho_hub/response'
 
 module ZohoHub
   class Connection
+    class << self
+      def infer_api_domain
+        case ZohoHub.configuration.api_domain
+        when 'https://accounts.zoho.com'    then 'https://www.zohoapis.com'
+        when 'https://accounts.zoho.com.cn' then 'https://www.zohoapis.com.cn'
+        when 'https://accounts.zoho.in'     then 'https://www.zohoapis.in'
+        when 'https://accounts.zoho.eu'     then 'https://www.zohoapis.eu'
+        else DEFAULT_DOMAIN
+        end
+      end
+    end
+
     attr_accessor :debug, :access_token, :expires_in, :api_domain, :refresh_token
 
     # This is a block to be run when the token is refreshed. This way you can do whatever you want
@@ -19,10 +31,10 @@ module ZohoHub
 
     BASE_PATH = '/crm/v2/'
 
-    def initialize(access_token:, api_domain: DEFAULT_DOMAIN, expires_in: 3600, refresh_token: nil)
+    def initialize(access_token:, api_domain: nil, expires_in: 3600, refresh_token: nil)
       @access_token = access_token
       @expires_in = expires_in
-      @api_domain = api_domain
+      @api_domain = api_domain || self.class.infer_api_domain
       @refresh_token ||= refresh_token # do not overwrite if it's already set
     end
 

--- a/spec/zoho_hub/connection_spec.rb
+++ b/spec/zoho_hub/connection_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'pry'
+require 'zoho_hub/connection'
+
+RSpec.describe ZohoHub::Connection do
+  context 'when initializing a new Connection' do
+    describe '@api_domain' do
+      it 'should correspond to config api_domain - US' do
+        ZohoHub.configuration.api_domain = 'https://accounts.zoho.com'
+        result = described_class.new(access_token: '').api_domain
+
+        expect(result).to eq('https://www.zohoapis.com')
+      end
+
+      it 'should correspond to config api_domain - CN' do
+        ZohoHub.configuration.api_domain = 'https://accounts.zoho.com.cn'
+        result = described_class.new(access_token: '').api_domain
+
+        expect(result).to eq('https://www.zohoapis.com.cn')
+      end
+
+      it 'should correspond to config api_domain - IN' do
+        ZohoHub.configuration.api_domain = 'https://accounts.zoho.in'
+        result = described_class.new(access_token: '').api_domain
+
+        expect(result).to eq('https://www.zohoapis.in')
+      end
+
+      it 'should correspond to config api_domain - EU' do
+        ZohoHub.configuration.api_domain = 'https://accounts.zoho.eu'
+        result = described_class.new(access_token: '').api_domain
+
+        expect(result).to eq('https://www.zohoapis.eu')
+      end
+
+      it 'should default if config api_domain is nil' do
+        ZohoHub.configuration.api_domain = nil
+        result = described_class.new(access_token: '').api_domain
+
+        expect(result).to eq(described_class::DEFAULT_DOMAIN)
+      end
+
+      it 'should default if config api_domain is empty' do
+        ZohoHub.configuration.api_domain = ''
+        result = described_class.new(access_token: '').api_domain
+
+        expect(result).to eq(described_class::DEFAULT_DOMAIN)
+      end
+
+      it 'should allow overriding via argument' do
+        ZohoHub.configuration.api_domain = 'https://accounts.zoho.eu'
+        connection = described_class.new(access_token: '',
+                                         api_domain: 'custom domain')
+        result = connection.api_domain
+
+        expect(result).to eq('custom domain')
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes #17

I added this as a class method since it seems to be generic class logic, but I am still getting a feel for how you've laid everything out and am happy to change it if you think it belongs elsewhere.

The case statement has one unnecessary step I left for the sake of explicitness and generic behavior in case `DEFAULT_DOMAIN` ever changes, but the `when 'https://accounts.zoho.eu'` line is logically redundant and could be removed. I'm happy to make that change too if you'd like.