### PR TITLE
Blueprint transitions: define a class method and raise when trying to…

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -74,6 +74,10 @@ module ZohoHub
         new(id: id).update(params)
       end
 
+      def blueprint_transition(id, transition_id, data = {})
+        new(id: id).blueprint_transition(transition_id, data)
+      end
+
       def all(params = {})
         params[:page] ||= DEFAULT_PAGE
         params[:per_page] ||= DEFAULT_RECORDS_PER_PAGE
@@ -103,6 +107,7 @@ module ZohoHub
         raise InvalidModule, response.msg if response.invalid_module?
         raise NoPermission, response.msg if response.no_permission?
         raise MandatoryNotFound, response.msg if response.mandatory_not_found?
+        raise RecordInBlueprint, response.msg if response.record_in_blueprint?
 
         response
       end

--- a/lib/zoho_hub/errors.rb
+++ b/lib/zoho_hub/errors.rb
@@ -19,6 +19,9 @@ module ZohoHub
   class MandatoryNotFound < StandardError
   end
 
+  class RecordInBlueprint < StandardError
+  end
+
   class ZohoAPIError < StandardError
   end
 end

--- a/lib/zoho_hub/response.rb
+++ b/lib/zoho_hub/response.rb
@@ -30,6 +30,10 @@ module ZohoHub
       error_code?('MANDATORY_NOT_FOUND')
     end
 
+    def record_in_blueprint?
+      error_code?('RECORD_IN_BLUEPRINT')
+    end
+
     def empty?
       @params.empty?
     end


### PR DESCRIPTION
One more small PR :smiley: 
I propose a class method for the Blueprint transitions, to be able to call `ZohoRecord.blueprint_transition(record_id, transition_id)` without fetching the record from Zoho first (same idea as the `update` class method).