### PR TITLE
Handle INTERNAL_ERROR response: raise InternalError instead of TypeError

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -103,6 +103,7 @@ module ZohoHub
         response = Response.new(body)
 
         raise InvalidTokenError, response.msg if response.invalid_token?
+        raise InternalError, response.msg if response.internal_error?
         raise RecordInvalid, response.msg if response.invalid_data?
         raise InvalidModule, response.msg if response.invalid_module?
         raise NoPermission, response.msg if response.no_permission?

--- a/lib/zoho_hub/errors.rb
+++ b/lib/zoho_hub/errors.rb
@@ -10,6 +10,9 @@ module ZohoHub
   class InvalidTokenError < StandardError
   end
 
+  class InternalError < StandardError
+  end
+
   class InvalidModule < StandardError
   end
 

--- a/lib/zoho_hub/response.rb
+++ b/lib/zoho_hub/response.rb
@@ -14,6 +14,10 @@ module ZohoHub
       error_code?('INVALID_TOKEN')
     end
 
+    def internal_error?
+      error_code?('INTERNAL_ERROR')
+    end
+
     def authentication_failure?
       error_code?('AUTHENTICATION_FAILURE')
     end


### PR DESCRIPTION
A small PR to raise a dedicated error for this API reply (currenty we get `TypeError: no implicit conversion of Symbol into Integer`) :
```
{
      "code": "INTERNAL_ERROR",
      "details": {},
      "message": "Internal Server Error",
      "status": "error"
}
```