### PR TITLE
Base record add note

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -82,6 +82,11 @@ module ZohoHub
         new(id: id).blueprint_transition(transition_id, data)
       end
 
+      def add_note(id:, title: '', content: '')
+        path = File.join(request_path, id, 'Notes')
+        post(path, data: [{ Note_Title: title, Note_Content: content }])
+      end
+
       def all(params = {})
         params[:page] ||= DEFAULT_PAGE
         params[:per_page] ||= DEFAULT_RECORDS_PER_PAGE


### PR DESCRIPTION
The goal is to be able to add a note to a record following [this API entry point](https://www.zoho.com/crm/developer/docs/api/create-specific-note.html).

I propose a very simple method to keep the signature clear. Example of use: `Zoho::Lead.add_note(id: '123456789', title: 'My Title', content: 'Some content')`. I think it is enough for 99% of the usecases, even if the API allows the creation of sereral notes for the same record in one call.