### PR TITLE
Record fix false value

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -82,6 +82,11 @@ module ZohoHub
         new(id: id).blueprint_transition(transition_id, data)
       end
 
+      def add_note(id:, title: '', content: '')
+        path = File.join(request_path, id, 'Notes')
+        post(path, data: [{ Note_Title: title, Note_Content: content }])
+      end
+
       def all(params = {})
         params[:page] ||= DEFAULT_PAGE
         params[:per_page] ||= DEFAULT_RECORDS_PER_PAGE

--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -126,8 +126,9 @@ module ZohoHub
     def initialize(params = {})
       attributes.each do |attr|
         zoho_key = attr_to_zoho_key(attr)
+        value = params[zoho_key].nil? ? params[attr] : params[zoho_key]
 
-        send("#{attr}=", params[zoho_key] || params[attr])
+        send("#{attr}=", value)
       end
     end
 

--- a/spec/zoho_hub/base_record_spec.rb
+++ b/spec/zoho_hub/base_record_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe ZohoHub::BaseRecord do
+  let(:test_class) do
+    Class.new(described_class) do
+      attributes :my_string, :my_bool
+    end
+  end
+
+  describe '#build_response' do
+    context 'with an empty string and a "false" boolean' do
+      # rubocop:disable Style/HashSyntax
+      let(:body) { { :data => [{ :My_String => '', :My_Bool => false }] } }
+      # rubocop:enable Style/HashSyntax
+
+      it 'correctly construct the record' do
+        response = test_class.build_response(body)
+        record = test_class.new(response.data.first)
+
+        expect(record.my_string).to eq('')
+        expect(record.my_bool).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a bug fix for `BaseRecord`: if an attribute is boolean, a `false` value in the Zoho API response was considered as `nil`.

This PR contains also the code from [my previous PR](https://github.com/rikas/zoho_hub/pull/40): a new method for adding notes. This is because my `master` is ahead from the main one, sorry for that.