### PR TITLE
Farday encode json

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -82,6 +82,11 @@ module ZohoHub
         new(id: id).blueprint_transition(transition_id, data)
       end
 
+      def add_note(id:, title: '', content: '')
+        path = File.join(request_path, id, 'Notes')
+        post(path, data: [{ Note_Title: title, Note_Content: content }])
+      end
+
       def all(params = {})
         params[:page] ||= DEFAULT_PAGE
         params[:per_page] ||= DEFAULT_RECORDS_PER_PAGE

--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -123,6 +123,7 @@ module ZohoHub
     def adapter
       Faraday.new(url: base_url) do |conn|
         conn.headers = authorization_header if access_token?
+        conn.use FaradayMiddleware::EncodeJson
         conn.use FaradayMiddleware::ParseJson
         conn.response :json, parser_options: { symbolize_names: true }
         conn.response :logger if ZohoHub.configuration.debug?

--- a/lib/zoho_hub/with_connection.rb
+++ b/lib/zoho_hub/with_connection.rb
@@ -13,11 +13,11 @@ module ZohoHub
       end
 
       def post(path, params = {})
-        ZohoHub.connection.post(path, params.to_json)
+        ZohoHub.connection.post(path, params)
       end
 
       def put(path, params = {})
-        ZohoHub.connection.put(path, params.to_json)
+        ZohoHub.connection.put(path, params)
       end
 
       def delete(path, params = {})


### PR DESCRIPTION
I propose to use [`FaradayMiddleware::EncodeJson`](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/request/encode_json.rb) instead of using `to_json` on our side. I find it cleaner and it is useful if we want to use the connection in other contexts  (in my case: bulk jobs).