### PR TITLE
Adds a GET request to retrieve the possible blueprint transitions of a record

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -82,6 +82,10 @@ module ZohoHub
         new(id: id).blueprint_transition(transition_id, data)
       end
 
+      def blueprint_transitions(id)
+        new(id: id).blueprint_transitions
+      end
+
       def add_note(id:, title: '', content: '')
         path = File.join(request_path, id, 'Notes')
         post(path, data: [{ Note_Title: title, Note_Content: content }])
@@ -153,6 +157,11 @@ module ZohoHub
     def blueprint_transition(transition_id, data = {})
       body = put(File.join(self.class.request_path, id, 'actions/blueprint'),
                  blueprint: [{ transition_id: transition_id, data: data }])
+      build_response(body)
+    end
+
+    def blueprint_transitions
+      body = get(File.join(self.class.request_path, id, 'actions/blueprint'))
       build_response(body)
     end
 


### PR DESCRIPTION
This PR adds the option to get all possible blueprint transitions for a given record, as discussed in #44 . I've implemented it in the same style as #23 

I would also like to add specs - do you already have a preferred way how to handle/mock the requests?

