### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Specify this module's fields as attributes:
 # lead.rb
 
 class Lead < ZohoHub::BaseRecord
-  attributes: :id, :first_name, :last_name, :phone, :email, :source, # etc.
+  attributes :id, :first_name, :last_name, :phone, :email, :source, # etc.
 end
 ```
 


### PR DESCRIPTION
This is a small fix to the README example of setting up attributes.