### PR TITLE
Ruby 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: ruby
 rvm:
 - 2.4.10
-- 2.5.8
-- 2.6.6
-- 2.7.1
+- 2.5.9
+- 2.6.7
+- 2.7.3
+- 3.0.1
 script:
 - bundle exec rubocop --version
 - bundle exec rubocop -c .rubocop.yml

--- a/examples/models/potential.rb
+++ b/examples/models/potential.rb
@@ -28,6 +28,8 @@ module ZohoHub
     )
 
     def initialize(params = {})
+      super
+
       attributes.each do |attr|
         zoho_key = attr_to_zoho_key(attr)
 

--- a/lib/zoho_hub.rb
+++ b/lib/zoho_hub.rb
@@ -41,7 +41,7 @@ module ZohoHub
 
     connection_params = params.dup.slice(:access_token, :expires_in, :api_domain, :refresh_token)
 
-    @connection = Connection.new(connection_params)
+    @connection = Connection.new(**connection_params)
   end
 
   def connection

--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -122,9 +122,7 @@ module ZohoHub
       end
 
       def update_all(records)
-        zoho_params = records.map do |record|
-          Hash[record.map { |key, value| [attr_to_zoho_key(key), value] }]
-        end
+        zoho_params = records.transform_keys { |key| attr_to_zoho_key(key) }
 
         body = put(File.join(request_path), data: zoho_params)
 
@@ -189,7 +187,7 @@ module ZohoHub
     end
 
     def update(params)
-      zoho_params = Hash[params.map { |k, v| [attr_to_zoho_key(k), v] }]
+      zoho_params = params.transform_keys { |key| attr_to_zoho_key(key) }
       body = put(File.join(self.class.request_path, id), data: [zoho_params])
 
       build_response(body)

--- a/lib/zoho_hub/connection.rb
+++ b/lib/zoho_hub/connection.rb
@@ -31,7 +31,7 @@ module ZohoHub
 
     BASE_PATH = '/crm/v2/'
 
-    def initialize(access_token:, api_domain: nil, expires_in: 3600, refresh_token: nil)
+    def initialize(access_token: nil, api_domain: nil, expires_in: 3600, refresh_token: nil)
       @access_token = access_token
       @expires_in = expires_in
       @api_domain = api_domain || self.class.infer_api_domain

--- a/lib/zoho_hub/response.rb
+++ b/lib/zoho_hub/response.rb
@@ -43,7 +43,7 @@ module ZohoHub
     end
 
     def data
-      data = @params[:data] if @params.dig(:data)
+      data = @params[:data] if @params[:data]
       data || @params
     end
 

--- a/lib/zoho_hub/with_attributes.rb
+++ b/lib/zoho_hub/with_attributes.rb
@@ -70,7 +70,7 @@ module ZohoHub
 
       return if new_attributes.empty?
 
-      attributes = Hash[new_attributes.map { |k, v| [k.to_s, v] }]
+      attributes = new_attributes.transform_keys(&:to_s)
       attributes.each do |k, v|
         assign_attribute(k, v)
       end


### PR DESCRIPTION
This PR adds a Travis config to test against Ruby 3.0.1, fixes the `Connection#initialize` definition and the `setup_config` call to `Connection.new`, and resolves some Rubocop errors.