### PR TITLE
Fix `update_all` to handle array input as expected

### DIFF
--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -122,7 +122,7 @@ module ZohoHub
       end
 
       def update_all(records)
-        zoho_params = records.transform_keys { |key| attr_to_zoho_key(key) }
+        zoho_params = records.map{ |record| record.transform_keys { |key| attr_to_zoho_key(key) } }
 
         body = put(File.join(request_path), data: zoho_params)
 

--- a/lib/zoho_hub/base_record.rb
+++ b/lib/zoho_hub/base_record.rb
@@ -122,7 +122,7 @@ module ZohoHub
       end
 
       def update_all(records)
-        zoho_params = records.map{ |record| record.transform_keys { |key| attr_to_zoho_key(key) } }
+        zoho_params = records.map { |record| record.transform_keys { |key| attr_to_zoho_key(key) } }
 
         body = put(File.join(request_path), data: zoho_params)
 


### PR DESCRIPTION
Intuitively, `update_all` should take an array of records, such as described in the readme. However this raises an error: 
> NoMethodError (undefined method `transform_keys' for #<Array:0x000056535fdac150>)
